### PR TITLE
Misc build clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/

--- a/src/ClipPing/App.axaml.cs
+++ b/src/ClipPing/App.axaml.cs
@@ -12,7 +12,7 @@ public partial class App : Application
     /// <summary>
     /// A window used only for the message loop
     /// </summary>
-    private Window _dummyWindow;
+    private Window? _dummyWindow;
 
     public override void Initialize()
     {

--- a/src/ClipPing/ClipPing.csproj
+++ b/src/ClipPing/ClipPing.csproj
@@ -10,6 +10,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishAot>true</PublishAot>
     <Version>1.1.0</Version>
+
+    <!-- trimming optimization: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options#trim-framework-library-features -->
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ClipPing/ClipPing.csproj
+++ b/src/ClipPing/ClipPing.csproj
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.999-cibuild0054097-alpha" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.999-cibuild0054097-alpha" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.999-cibuild0054097-alpha" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.999-cibuild0054097-alpha" />
+    <PackageReference Include="Avalonia" Version="11.3.*-*" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.*-*" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.*-*" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.*-*" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.999-cibuild0054097-alpha">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.*-*">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>

--- a/src/ClipPing/Overlays/BorderOverlay.axaml.cs
+++ b/src/ClipPing/Overlays/BorderOverlay.axaml.cs
@@ -19,11 +19,12 @@ public partial class BorderOverlay : Window, IOverlay
 
         Show();
 
-        var appear = (Animation)Resources["Appear"];
-        var disappear = (Animation)Resources["Disappear"];
-
-        await appear.RunAsync(this);
-        await disappear.RunAsync(this);
+        if(Resources["Appear"] is Animation appear &&
+           Resources["Disappear"] is Animation disappear)
+        {
+            await appear.RunAsync(this);
+            await disappear.RunAsync(this);
+        }
 
         Close();
     }

--- a/src/ClipPing/Overlays/TopOverlay.axaml.cs
+++ b/src/ClipPing/Overlays/TopOverlay.axaml.cs
@@ -19,11 +19,12 @@ public partial class TopOverlay : Window, IOverlay
 
         Show();
 
-        var appear = (Animation)Resources["Appear"];
-        var disappear = (Animation)Resources["Disappear"];
-
-        await appear.RunAsync(this);
-        await disappear.RunAsync(this);
+        if(Resources["Appear"] is Animation appear &&
+           Resources["Disappear"] is Animation disappear)
+        {
+            await appear.RunAsync(this);
+            await disappear.RunAsync(this);
+        }
 
         Close();
     }

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+  <packageSources>
+    <!-- nightly feed -->
+    <add key="avalonia-nightly" value="https://nuget-feed-nightly.avaloniaui.net/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Miscellaneous cleanup to remove build errors and warnings. This should enable building the project as-is without further changes.

The main issue I had building the project was the missing Avalonia nuget packages.
- add `nuget.config` with Avalonia's nightly build nuget feed (you can't build the project otherwise)

After this, I could build the project, but with nuget warnings about not finding the specific package versions requested, since `11.3.999-cibuild0054097-alpha` is no longer available in the feed above.
- updated the nuget Avalonia package references to `11.3.*-*` to use the latest nightly build

The compiler also raised a few nullability warnings.
- resolve compiler warnings by adding a nullable annotation and a few null checks

Bonus:
- add `.idea/` directory (JetBrains Rider) to `.gitignore`
- enable [invariant globalization mode](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization#invariant-mode) to reduce trimmed binary size (saved about ~210KB in the final `.exe`). I tried a few other settings from [Trim framework library features](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options#trim-framework-library-features), but the effects were minimal (or none), and I didn't want to risk breaking anything.
