### PR TITLE
Make sure only one instance is running

### DIFF
--- a/src/ClipPing/ClipPing.cpp
+++ b/src/ClipPing/ClipPing.cpp
@@ -198,6 +198,24 @@ struct AppState
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR, int)
 {
+	// Single-instance check: if another instance is already running,
+	// signal it to open its settings window and exit.
+	const auto mutex = CreateMutex(nullptr, FALSE, L"ClipPing_SingleInstance");
+	if (GetLastError() == ERROR_ALREADY_EXISTS)
+	{
+		const auto existingWnd = FindWindow(L"ClipPingListener", nullptr);
+		if (existingWnd)
+		{
+			DWORD pid = 0;
+			GetWindowThreadProcessId(existingWnd, &pid);
+			AllowSetForegroundWindow(pid);
+			PostMessage(existingWnd, WM_COMMAND, IDM_SETTINGS, 0);
+		}
+
+		CloseHandle(mutex);
+		return 0;
+	}
+
 	SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
 	AppState app(hInstance);
@@ -251,5 +269,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR, int)
 
 	Gdiplus::GdiplusShutdown(gdiplusToken);
 
+	CloseHandle(mutex);
 	return (int)msg.wParam;
 }

--- a/src/ClipPing/Settings.cpp
+++ b/src/ClipPing/Settings.cpp
@@ -136,6 +136,12 @@ void Settings::Save()
 
 bool Settings::ShowDialog(HWND parent, HINSTANCE instance, Overlay& overlay)
 {
+	if (_dialogHwnd)
+	{
+		SetForegroundWindow(_dialogHwnd);
+		return false;
+	}
+
 	_dlgColor = overlayColor;
 	DlgContext ctx(this, &overlay);
 	return DialogBoxParam(instance, MAKEINTRESOURCE(IDD_SETTINGS), parent, DlgProc, (LPARAM)&ctx) == IDOK;
@@ -151,6 +157,7 @@ INT_PTR CALLBACK Settings::DlgProc(HWND dialog, UINT msg, WPARAM wParam, LPARAM 
 	{
 		ctx = (DlgContext*)lParam;
 		SetWindowLongPtr(dialog, DWLP_USER, lParam);
+		ctx->settings->_dialogHwnd = dialog;
 
 		CheckDlgButton(dialog, IDC_CHK_AUTOSTART,
 			(ctx->settings->isFirstLaunch || GetAutoStart()) ? BST_CHECKED : BST_UNCHECKED);
@@ -165,6 +172,15 @@ INT_PTR CALLBACK Settings::DlgProc(HWND dialog, UINT msg, WPARAM wParam, LPARAM 
 		SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM)L"Right");
 		SendMessage(hCombo, CB_SETCURSEL, (WPARAM)ctx->settings->overlayType, 0);
 
+		return TRUE;
+	}
+
+	case WM_DESTROY:
+	{
+		if (ctx)
+		{
+			ctx->settings->_dialogHwnd = nullptr;
+		}
 		return TRUE;
 	}
 

--- a/src/ClipPing/Settings.h
+++ b/src/ClipPing/Settings.h
@@ -44,5 +44,6 @@ private:
 	void EnsureIniPath();
 
 	COLORREF _dlgColor = 0;
+	HWND _dialogHwnd = nullptr;
 	std::wstring _iniPath;
 };


### PR DESCRIPTION
If another instance is running, open the settings dialog.